### PR TITLE
fix: return different uuid for each chat completion stream

### DIFF
--- a/langchain_openai_api_bridge/chat_completion/langchain_stream_adapter.py
+++ b/langchain_openai_api_bridge/chat_completion/langchain_stream_adapter.py
@@ -21,8 +21,10 @@ class LangchainStreamAdapter:
     async def ato_chat_completion_chunk_stream(
         self,
         astream_event: AsyncIterator[StreamEvent],
-        id: str = str(uuid.uuid4()),
+        id: str = "",
     ) -> AsyncIterator[OpenAIChatCompletionChunkObject]:
+        if id == "":
+            id = str(uuid.uuid4())
         async for event in astream_event:
             kind = event["event"]
             match kind:


### PR DESCRIPTION
This pull request is to update the code so that different uuid could be returned for each chat completion stream.

This moved the build uuid method to the function block rather as a default value, so that it could generate a new value every time when the function is called. 