### PR TITLE
chore: Fix Python version restriction in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/samuelint/langchain-openai-api-bridge"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0"
+python = ">=3.10,<4.0"
 openai = "^1.35.1"
 
 langchain = { version = "^0.2.6", optional = true }


### PR DESCRIPTION
The match statement and the type union operator (Type | Type) are supported since Python 3.10.